### PR TITLE
Release v1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-weatherflow-tempest",
-  "version": "1.0.2",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-weatherflow-tempest",
-      "version": "1.0.2",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.1.3"
@@ -25,6 +25,10 @@
       "engines": {
         "homebridge": ">=1.3.5",
         "node": ">=14.18.1"
+      },
+      "funding": {
+        "type": "paypal",
+        "url": "https://paypal.me/chasenicholl"
       }
     },
     "node_modules/@cspotcode/source-map-consumer": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": false,
   "displayName": "Homebridge WeatherFlow Tempest",
   "name": "homebridge-weatherflow-tempest",
-  "version": "1.1.6",
+  "version": "1.2.0",
   "description": "Exposes WeatherFlow Tempest Station data as Temperature Sensors, Light Sensors, Humidity Sensors and Fan Sensors (for Wind Speed).",
   "license": "Apache-2.0",
   "repository": {
@@ -41,7 +41,7 @@
     "axios": "^1.1.3"
   },
   "funding": {
-    "type" : "paypal",
-    "url" : "https://paypal.me/chasenicholl"
+    "type": "paypal",
+    "url": "https://paypal.me/chasenicholl"
   }
 }

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -48,13 +48,18 @@ export class WeatherFlowTempestPlatform implements DynamicPlatformPlugin {
       log.info('Executed didFinishLaunching callback');
 
       if (this.areSensorsSet() === false) {
-        log.info('No Sensors configured - refusing to continue.');
+        log.info('No Sensors configured. Refusing to continue.');
         return;
       }
 
       try {
 
         this.tempestApi.getStationCurrentObservation().then( (observation_data: Observation) => {
+
+          if (!observation_data) {
+            log.info('Failed to fetch initial Station Current Observations after retrying. Refusing to continue.');
+            return;
+          }
 
           // Cache the observation results
           this.observation_data = observation_data;
@@ -82,14 +87,22 @@ export class WeatherFlowTempestPlatform implements DynamicPlatformPlugin {
     // Poll Tempest API
     const interval = (this.config.interval as number || 10) * 1000;
     this.log.debug(`Tempest API Polling interval (ms) -> ${interval}`);
+
     const tick = () => {
+
       setTimeout( () => {
-        this.tempestApi.getStationCurrentObservation().then( (observation_data) => {
+
+        this.tempestApi.getStationCurrentObservation().then( (observation_data: Observation) => {
+
           this.observation_data = observation_data;
           timer = setTimeout(tick, interval);
+
         });
+
       }, interval);
+
     };
+
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     let timer = setTimeout(tick, interval);
 

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -38,8 +38,9 @@ class TemperatureSensor {
   private getCurrentTemperature(): number {
 
     try {
+
       const value_key: string = this.accessory.context.device.value_key;
-      const temperature: number = parseFloat(this.platform.observation_data['obs'][0][value_key]);
+      const temperature: number = parseFloat(this.platform.observation_data[value_key]);
       if (temperature > 100.00) {
         this.platform.log.debug(`WeatherFlow Tempest is reporting temperatures exceeding 100c: ${temperature}c`);
         return 100;
@@ -98,7 +99,7 @@ class LightSensor {
   private getCurrentLux(): number {
     try {
       const value_key: string = this.accessory.context.device.value_key;
-      const lux: number = parseFloat(this.platform.observation_data['obs'][0][value_key]);
+      const lux: number = parseFloat(this.platform.observation_data[value_key]);
       if (lux < 0.0001) {
         this.platform.log.debug(`WeatherFlow Tempest is reporting lux less than 0.0001: ${lux}`);
         return 0.0001;
@@ -152,7 +153,7 @@ class HumiditySensor {
   private getCurrentRelativeHumidity(): number {
     try {
       const value_key: string = this.accessory.context.device.value_key;
-      const relative_humidity: number = parseInt(this.platform.observation_data['obs'][0][value_key]);
+      const relative_humidity: number = parseInt(this.platform.observation_data[value_key]);
       if (relative_humidity > 100) {
         this.platform.log.debug(`WeatherFlow Tempest is reporting relative humidity exceeding 100%: ${relative_humidity}%`);
         return 100;
@@ -213,7 +214,7 @@ class Fan {
   private getCurrentWindSpeed(): number {
     try {
       const value_key: string = this.accessory.context.device.value_key;
-      const speed: number = parseInt(this.platform.observation_data['obs'][0][value_key]);
+      const speed: number = parseInt(this.platform.observation_data[value_key]);
       if (speed > 100) {
         this.platform.log.debug(`WeatherFlow Tempest is reporting wind speed exceeding 100mph: ${speed}mph`);
         return 100;

--- a/src/tempestApi.ts
+++ b/src/tempestApi.ts
@@ -17,6 +17,7 @@ export class TempestApi {
   private token: string;
   private station_id: string;
   private data: object | undefined;
+  private readonly max_retries: number = 30;
 
   constructor(token: string, station_id: string, log: Logger) {
 
@@ -50,7 +51,12 @@ export class TempestApi {
 
   }
 
-  public async getStationCurrentObservation() {
+  public async getStationCurrentObservation(retry_count = 0) {
+
+    if (retry_count === this.max_retries) {
+      this.log.error(`Reached max API retries: ${this.max_retries}. Stopping.`);
+      return;
+    }
 
     const response: AxiosResponse | undefined = await this.getStationObservation();
     if (!response || !response.data || !('obs' in response.data)) {
@@ -59,9 +65,9 @@ export class TempestApi {
         this.log.warn('Returning last cached response.');
         return this.data;
       }
-      this.log.warn('Retrying. No cached "obs" data.');
-      await this.delay(1000);
-      return await this.getStationCurrentObservation();
+      this.log.warn(`Retrying ${retry_count + 1} of ${this.max_retries}. No cached "obs" data.`);
+      await this.delay(1000 * retry_count);
+      return await this.getStationCurrentObservation(retry_count + 1);
     } else {
       this.data = response.data['obs'][0];
       return this.data;

--- a/src/tempestApi.ts
+++ b/src/tempestApi.ts
@@ -1,13 +1,7 @@
 import { Logger } from 'homebridge';
 import axios, { AxiosResponse } from 'axios';
 
-interface StationUnits {
-  units_temp: string;
-  units_wind: string;
-  units_precip: string;
-}
-
-interface Observation {
+export interface Observation {
   air_temperature: number;
   feels_like: number;
   relative_humidity: number;
@@ -17,44 +11,60 @@ interface Observation {
   brightness: number;
 }
 
-export interface TempestObservation {
-  station_units: StationUnits;
-  obs: Array<Observation>;
-}
-
 export class TempestApi {
 
   private log: Logger;
   private token: string;
   private station_id: string;
+  private data: object | undefined;
 
   constructor(token: string, station_id: string, log: Logger) {
 
     this.log = log;
     this.token = token;
     this.station_id = station_id;
+    this.data = undefined;
 
     this.log.info('TempestApi initialized.');
 
   }
 
-  public async getStationCurrentObservation() {
+  private async getStationObservation() {
 
-    const url = `https://swd.weatherflow.com/swd/rest/observations/station/${this.station_id}`;
     try {
-      const body: AxiosResponse = await axios.get(
-        url, {
-          headers: {
-            'Authorization': `Bearer ${this.token}`,
-            'Accept': 'application/json',
-          },
-          responseType: 'json',
-        },
-      );
-      this.log.debug(`[WeatherFlow] Response Code: ${body.status.toString()}`);
-      return body.data;
+      const url = `https://swd.weatherflow.com/swd/rest/observations/station/${this.station_id}`;
+      const headers = {
+        Authorization: `Bearer ${this.token}`,
+        Accept: 'application/json',
+      };
+      return await axios.get(url, {headers: headers, responseType: 'json'});
     } catch(exception) {
       this.log.debug(`[WeatherFlow] ${exception}`);
+    }
+
+  }
+
+  private async delay(ms: number) {
+
+    return new Promise(resolve => setTimeout(resolve, ms));
+
+  }
+
+  public async getStationCurrentObservation() {
+
+    const response: AxiosResponse | undefined = await this.getStationObservation();
+    if (!response || !response.data || !('obs' in response.data)) {
+      this.log.warn('Response missing "obs" data.');
+      if (this.data !== undefined) {
+        this.log.warn('Returning last cached response.');
+        return this.data;
+      }
+      this.log.warn('Retrying. No cached "obs" data.');
+      await this.delay(1000);
+      return await this.getStationCurrentObservation();
+    } else {
+      this.data = response.data['obs'][0];
+      return this.data;
     }
 
   }


### PR DESCRIPTION
## [1.2.0] - 2022-11-09

Gracefully handle occasional REST API response failures.

### Added
- REST API retry logic. 
  - Linear retry delays up to 30. 1 second, 2 second...30 second.
- Initialization of platform will fail if the first request for data never succeeds.
- After at least 1 successful API response, subsequent request failures will use the last cached values and will continue to poll API at user configured interval.

### Changed
- n/a

### Removed
- n/a