### PR TITLE
adding motion sensor and station id type checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,13 @@
 <img src="https://weatherflow.com/wp-content/uploads/2016/05/Tempest-powered-by-01.svg" width="250">
 </p>
 
-Homebridge Plugin providing basic WeatherFlow Tempest support. Including Temperature Sensor, Humidity Sensor, Light Sensor and Fan (Wind Speed, 0-100mph).
+Homebridge Plugin providing basic WeatherFlow Tempest support. Exposing 5 Acessories.
+
+- Temperature Sensor
+- Humidity Sensor
+- Light Sensor
+- Motion Sensor (triggered by user configured value)
+- Fan (expressed as Rotation Speed - Wind Speed 0-100mph)
 
 ### Setup and Parameters
 
@@ -17,10 +23,12 @@ You will need to create an account at https://tempestwx.com/ and then generate a
 - `token`: _(Required)_ Oauth2 Personal Use Token, create via your tempestwx account.
 - `station_id`: _(Required)_ The station ID you are pulling weather data from.
 - `interval`: _(Required)_ How often to poll the Tempest REST API. Default 10 seconds. Minimum every second.
+
 - `sensors`: _(Required)_ An array of sensors to create. This is dynamic incase you want to target different temperature or wind speed attributes.
-- `sensors.name`: _(Required)_ Display name of Sensor in Apple Home.
-- `sensors.sensor_type`: _(Required)_ The type of Home Sensor to create. There are 4 options ["Temperature Sensor", "Light Sensor", "Humidity Sensor", "Fan"].
-- `sensors.value_key`: _(Required)_ Which REST API response body key to target for its value. If you'd like to use different temperature or wind speeds. You can find the available keys here: https://weatherflow.github.io/Tempest/api/swagger/#!/observations/getStationObservation.
+- `sensors[].name`: _(Required)_ Display name of Sensor in Apple Home.
+- `sensors[].sensor_type`: _(Required)_ The type of Home Sensor to create. There are 4 options ["Temperature Sensor", "Light Sensor", "Humidity Sensor", "Fan", "Motion Sensor"].
+- `sensors[].value_key`: _(Required)_ Which REST API response body key to target for its value. If you'd like to use different temperature or wind speeds. You can find the available keys here: https://weatherflow.github.io/Tempest/api/swagger/#!/observations/getStationObservation.
+- `sensors[].additional_properties.motion_trigger_value`: _(Required with Motion Sensor)_ At what point (value) to trigger motion detected on/off. Minimum 1.
 
 #### Config Example
 
@@ -28,7 +36,7 @@ You will need to create an account at https://tempestwx.com/ and then generate a
 {
   "name": "WeatherFlow Tempest Platform",
   "token": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX",
-  "station_id": "10000",
+  "station_id": 10000,
   "interval": 10,
   "sensors": [
     {
@@ -37,19 +45,27 @@ You will need to create an account at https://tempestwx.com/ and then generate a
       "value_key": "air_temperature"
     },
     {
-       "name": "Outside Relative Humidity",
-       "sensor_type": "Humidity Sensor",
-       "value_key": "relative_humidity"
+      "name": "Outside Relative Humidity",
+      "sensor_type": "Humidity Sensor",
+      "value_key": "relative_humidity"
     },
     {
-       "name": "Outside Light Level",
-       "sensor_type": "Light Sensor",
-       "value_key": "brightness"
+      "name": "Outside Light Level",
+      "sensor_type": "Light Sensor",
+      "value_key": "brightness"
     },
     {
-       "name": "Outside Wind Speed",
-       "sensor_type": "Fan",
-       "value_key": "wind_avg"
+      "name": "Outside Wind Speed",
+      "sensor_type": "Fan",
+      "value_key": "wind_avg"
+    },
+    {
+      "name": "Wind Speed Detector",
+      "sensor_type": "Motion Sensor",
+      "value_key": "wind_gust",
+      "additional_properties": {
+        "motion_trigger_value": 30
+      }
     },
   ],
   "platform": "WeatherFlowTempest"

--- a/config.schema.json
+++ b/config.schema.json
@@ -1,53 +1,77 @@
 {
-  "pluginAlias": "WeatherFlowTempest",
-  "pluginType": "platform",
-  "singular": true,
-  "schema": {
-    "type": "object",
-    "properties": {
-      "name": {
-        "title": "Name",
-        "type": "string",
-        "required": true,
-        "default": "WeatherFlow Tempest Platform"
-      },
-      "token": {
-        "title": "Token",
-        "type": "string",
-        "required": true
-      },
-      "station_id": {
-        "title": "Station ID",
-        "type": "string",
-        "required": true
-      },
-      "interval": {
-        "type": "integer",
-        "default": 10,
-        "minimum": 1
-      },
-      "sensors": {
-        "title": "Weather Sensors",
-        "description": "Enable WeatherFlow Tempest Sensors.",
-        "type": "array",
-        "items": {
-          "type": "object",
-          "properties": {
+    "pluginAlias": "WeatherFlowTempest",
+    "pluginType": "platform",
+    "singular": false,
+    "schema": {
+        "type": "object",
+        "properties": {
             "name": {
-              "type": "string"
-            },
-            "sensor_type": {
+                "title": "Name",
                 "type": "string",
-                "enum": ["Temperature Sensor", "Light Sensor", "Humidity Sensor", "Fan"]
+                "required": true,
+                "default": "WeatherFlow Tempest Platform"
             },
-            "value_key": {
-              "type": "string"
+            "token": {
+                "title": "Token",
+                "type": "string",
+                "required": true
+            },
+            "station_id": {
+                "title": "Station ID (Integer)",
+                "type": "number",
+                "required": true
+            },
+            "interval": {
+                "type": "integer",
+                "default": 10,
+                "minimum": 1
+            },
+            "sensors": {
+                "title": "Weather Sensors",
+                "description": "Enable WeatherFlow Tempest Sensors.",
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "sensor_type": {
+                            "type": "string",
+                            "enum": [
+                                "Temperature Sensor",
+                                "Light Sensor",
+                                "Humidity Sensor",
+                                "Fan",
+                                "Motion Sensor"
+                            ],
+                            "default": "Temperature Sensor"
+                        },
+                        "value_key": {
+                            "type": "string"
+                        },
+                        "additional_properties": {
+                            "title": "Additional Properties",
+                            "type": "object",
+                            "condition": {
+                              "functionBody": "if (model.sensors[arrayIndices] && model.sensors[arrayIndices].sensor_type && model.sensors[arrayIndices].sensor_type === 'Motion Sensor') { return true; } else { return false; };"
+                            },
+                            "properties": {
+                                "motion_trigger_value": {
+                                    "type": "number",
+                                    "minimum": 1,
+                                    "description": "At what point (value) to trigger motion detected on/off."
+                                }
+                            }
+                        }
+                    }
+                },
+                "required": [
+                    "name",
+                    "sensor_type",
+                    "value_key"
+                ]
             }
-            
-          }
-        },
-        "required": ["name", "sensor_type", "value_key"]
-      }
+        }
     }
-  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "homebridge-weatherflow-tempest",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-weatherflow-tempest",
-      "version": "1.2.0",
+      "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "axios": "^1.1.3"
+        "axios": "1.1.3"
       },
       "devDependencies": {
         "@types/node": "^16.10.9",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": false,
   "displayName": "Homebridge WeatherFlow Tempest",
   "name": "homebridge-weatherflow-tempest",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Exposes WeatherFlow Tempest Station data as Temperature Sensors, Light Sensors, Humidity Sensors and Fan Sensors (for Wind Speed).",
   "license": "Apache-2.0",
   "repository": {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -43,6 +43,15 @@ export class WeatherFlowTempestPlatform implements DynamicPlatformPlugin {
       brightness: 0,
     };
 
+    // Make sure the Station ID is the integer ID
+    if (isNaN(this.config.station_id)) {
+      log.warn(
+        'Station ID is not an Integer! Please make sure you are using the ID integer found here: ' +
+        'https://tempestwx.com/station/<STATION_ID>/',
+      );
+      return;
+    }
+
     this.api.on('didFinishLaunching', () => {
 
       log.info('Executed didFinishLaunching callback');


### PR DESCRIPTION
## [2.0.0] - 2022-12-20

### Added
- Motion Sensor. Triggered by user specified value. Inspired by #3. Motion Sensors can be used to trigger events like alarms for high wind gusts at night.
    - `additional_properties.motion_trigger_value`

### Changed
- Station ID must be an integer. Now explicit in schema and type checked durning plugin initialization.

### Removed
- n/a
