### PR TITLE
feat: Added local_api_shared configuration option.

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -18,6 +18,12 @@
             "required": true,
             "default": true
           },
+          "local_api_shared": {
+            "title": "Share the Local API UDP port with other processes",
+            "type": "boolean",
+            "required": false,
+            "default": false
+          },
           "token": {
               "title": "Token",
               "type": "string",

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -66,6 +66,12 @@ export class WeatherFlowTempestPlatform implements DynamicPlatformPlugin {
       this.log.info('local_api config parameter not set defaulting to false.');
     }
 
+    // Backwards compatible config check for new local_api_shared variable
+    if (!('local_api_shared' in this.config)) {
+      this.config['local_api_shared'] = false;
+      this.log.info('local_api_shared config parameter not set defaulting to false.');
+    }
+
     // For new install with local_api === true (Local API), token and station_id will be undefined and are not required
 
     // For local_api === false (HTTP API), make sure token is provided
@@ -112,7 +118,7 @@ export class WeatherFlowTempestPlatform implements DynamicPlatformPlugin {
 
     try {
       this.log.info('Using Tempest Local API.');
-      this.tempestSocket = new TempestSocket(this.log);
+      this.tempestSocket = new TempestSocket(this.log, this.config.local_api_shared);
       this.tempestSocket.start();
 
       // Hold thread for first message and set values

--- a/src/tempest.ts
+++ b/src/tempest.ts
@@ -41,12 +41,12 @@ export class TempestSocket {
   private data: object | undefined;
   private tempest_battery_level: number;
 
-  constructor(log: Logger) {
+  constructor(log: Logger, reuse_address: boolean) {
 
     this.log = log;
     this.data = undefined;
     this.tempest_battery_level = 0;
-    this.s = dgram.createSocket('udp4');
+    this.s = dgram.createSocket({ type: 'udp4', reuseAddr: reuse_address });
 
     this.log.info('TempestSocket initialized.');
 


### PR DESCRIPTION
This new option, which is `false` by default in order to not interfere with existing working installations, allows to share the UDP socket with other processes running on the same machine as the `homebridge-weatherflow-tempest` plugin.

Closes #26.