### PR TITLE
add firewall docs, configurable UDP port, and no-data warnings for Local API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. This project uses [Semantic Versioning](https://semver.org/).
 
+## v4.2.0
+* Added configurable UDP port via new optional `local_api_port` setting (defaults to `50222`). Useful for Docker containers, port forwarding, and UDP relay setups.
+* Added firewall configuration documentation to README for Linux (ufw, firewalld, iptables), macOS, and Docker.
+* Added same-subnet/VLAN networking requirement note for Local API users.
+* Log the configured UDP port on startup when using Local API.
+* Added periodic warning when no UDP data is received during initial startup (every 90 seconds) with troubleshooting hints.
+* Added stale data detection: warns if no broadcast received in over 3 minutes after initial connection.
+
 ## v4.1.1
 * Update README.md to correctly display "Tempest" logo.
 * Update README.md to include `station_id` in "Local API Config Example".

--- a/README.md
+++ b/README.md
@@ -37,10 +37,42 @@ Local API is now supported which requires no authentication. If you choose to us
 
 - `name`: _(Required)_ Must always be set to `WeatherFlow Tempest Platform`.
 - `local_api`: _(Required)_ Use the Local API versus HTTP API.
+- `local_api_port`: _(Optional, Local API only)_ UDP port to listen on for Tempest hub broadcasts. Defaults to `50222`. Only change this if you need to remap the port (e.g., in a Docker container or behind a UDP relay).
 - `token`: _(Required for HTTP API)_ Oauth2 Personal Use Token, create via your tempestwx account.
 - `station_id`: _(Required for HTTP API)_ The station ID you are pulling weather data from.
 - `interval`: _(Required for HTTP API)_ How often to poll the Tempest REST API. Default 10 seconds. Minimum every second.
 - `local_api_shared`: _(Optional)_ enable multicast. Will reuse the address, even if another process has already bound a socket on it, but only one socket can receive the data. Default: False.
+
+### Firewall Configuration (Required for Local API)
+
+The Tempest hub broadcasts weather observations via UDP on port **50222** (or your configured `local_api_port`). The host running Homebridge **must** allow incoming UDP traffic on this port or the plugin will not receive any data.
+
+> **Important:** The Tempest hub uses UDP broadcast, so the Homebridge host must be on the **same Layer 2 network** (subnet/VLAN) as the hub. Broadcasts do not cross routers or VLANs without additional configuration (e.g., a UDP relay/proxy).
+
+**Linux (ufw):**
+```bash
+sudo ufw allow 50222/udp
+```
+
+**Linux (firewalld):**
+```bash
+sudo firewall-cmd --permanent --add-port=50222/udp
+sudo firewall-cmd --reload
+```
+
+**Linux (iptables):**
+```bash
+sudo iptables -A INPUT -p udp --dport 50222 -j ACCEPT
+```
+
+**macOS:**
+If the macOS application firewall is enabled, ensure that Node.js (or the Homebridge process) is allowed to accept incoming connections. You may be prompted automatically on first run.
+
+**Docker / Containers:**
+You must map UDP port 50222 into the container:
+```bash
+docker run ... -p 50222:50222/udp ...
+```
 - `sensors`: _(Required)_ An array of sensors to create. This is dynamic incase you want to target different temperature or wind speed attributes.
 - `sensors[].name`: _(Required)_ Display name of Sensor in Apple Home.
 - `sensors[].sensor_type`: _(Required)_ The type of Home Sensor to create. There are 6 options ["Temperature Sensor", "Light Sensor", "Humidity Sensor", "Fan", "Motion Sensor", "Occupancy Sensor"].
@@ -79,6 +111,7 @@ sensor_type `{2}` | value_key | metric units | std units | additional_properties
 {
   "name": "WeatherFlow Tempest Platform",
   "local_api": true,
+  "local_api_port": 50222,
   "station_id": 10000,
   "units": "Standard",
   "local_api_shared": false,

--- a/config.schema.json
+++ b/config.schema.json
@@ -24,6 +24,17 @@
             "required": false,
             "default": false
           },
+          "local_api_port": {
+            "title": "Local API UDP Port",
+            "type": "integer",
+            "default": 50222,
+            "minimum": 1,
+            "maximum": 65535,
+            "description": "UDP port to listen on for Tempest hub broadcasts. Default is 50222. Only change this if you have port forwarding or container port remapping in place.",
+            "condition": {
+              "functionBody": "return model.local_api === true;"
+            }
+          },
           "token": {
               "title": "Token",
               "type": "string",

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -72,6 +72,11 @@ export class WeatherFlowTempestPlatform implements DynamicPlatformPlugin {
       this.log.info('local_api_shared config parameter not set defaulting to false.');
     }
 
+    // Backwards compatible config check for new local_api_port variable
+    if (!('local_api_port' in this.config)) {
+      this.config['local_api_port'] = 50222;
+    }
+
     // For new install with local_api === true (Local API), token and station_id will be undefined and are not required
 
     // For local_api === false (HTTP API), make sure token is provided
@@ -119,7 +124,9 @@ export class WeatherFlowTempestPlatform implements DynamicPlatformPlugin {
     try {
       this.log.info('Using Tempest Local API.');
       this.tempestSocket = new TempestSocket(this.log, this.config.local_api_shared);
-      this.tempestSocket.start();
+      const udpPort = this.config.local_api_port as number || 50222;
+      this.log.info(`Listening for Tempest UDP broadcasts on port ${udpPort}.`);
+      this.tempestSocket.start('0.0.0.0', udpPort);
 
       // Hold thread for first message and set values
       await this.socketDataRecieved();
@@ -147,6 +154,7 @@ export class WeatherFlowTempestPlatform implements DynamicPlatformPlugin {
 
     this.log.info('Waiting for first local broadcast. This could take up to 60 seconds...');
     return new Promise((resolve) => {
+      let waitSeconds = 0;
       const socket_interval = setInterval(() => {
         if (this.tempestSocket === undefined) {
           return;
@@ -155,6 +163,15 @@ export class WeatherFlowTempestPlatform implements DynamicPlatformPlugin {
           clearInterval(socket_interval);
           this.log.info('Initial local broadcast recieved.');
           resolve();
+        } else {
+          waitSeconds += 1;
+          if (waitSeconds > 0 && waitSeconds % 90 === 0) {
+            this.log.warn(
+              `No UDP data received after ${waitSeconds} seconds. ` +
+              'Ensure UDP port is not blocked by a firewall and that the Homebridge host ' +
+              'is on the same subnet/VLAN as the Tempest hub.',
+            );
+          }
         }
       }, 1000);
     });
@@ -221,6 +238,18 @@ export class WeatherFlowTempestPlatform implements DynamicPlatformPlugin {
 
       if (this.tempestSocket === undefined) {
         return;
+      }
+
+      // Check for stale data (no broadcast received in over 3 minutes)
+      const lastTimestamp = this.tempestSocket.getLastDataTimestamp();
+      if (lastTimestamp > 0) {
+        const staleSec = (Date.now() - lastTimestamp) / 1000;
+        if (staleSec > 180) {
+          this.log.warn(
+            `No UDP broadcast received in ${Math.round(staleSec)} seconds. ` +
+            'The Tempest hub may be offline or unreachable.',
+          );
+        }
       }
 
       // Update values

--- a/src/tempest.ts
+++ b/src/tempest.ts
@@ -40,12 +40,14 @@ export class TempestSocket {
   private s: dgram.Socket;
   private data: object | undefined;
   private tempest_battery_level: number;
+  private last_data_timestamp: number;
 
   constructor(log: Logger, reuse_address: boolean) {
 
     this.log = log;
     this.data = undefined;
     this.tempest_battery_level = 0;
+    this.last_data_timestamp = 0;
     this.s = dgram.createSocket({ type: 'udp4', reuseAddr: reuse_address });
 
     this.log.info('TempestSocket initialized.');
@@ -89,6 +91,7 @@ export class TempestSocket {
 
   private setTempestData(data): void {
 
+    this.last_data_timestamp = Date.now();
     const obs = data.obs[0];
     // const windLull = (obs[1] !== null) ? obs[1] : 0;
     const windSpeed = (obs[2] !== null) ? obs[2] * 2.2369 : 0; // convert to mph for heatindex calculation
@@ -147,6 +150,10 @@ export class TempestSocket {
 
   public getBatteryLevel(): number {
     return this.tempest_battery_level;
+  }
+
+  public getLastDataTimestamp(): number {
+    return this.last_data_timestamp;
   }
 
 }


### PR DESCRIPTION
If you use `local_api: true` and have a host firewall enabled (which is pretty common on Linux), the plugin silently hangs forever waiting for its first broadcast. There's nothing in the README about needing to open the UDP port, and the logs just say "Waiting for first local broadcast..." with no follow-up. It's not obvious what's wrong.

Everything is optional and defaults to existing behavior. Existing configs work as-is.